### PR TITLE
Fix version mismatch in documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Tested that both gcc and clang-12 will successfully compile all executables
 #
-# clang-12 produces code that is slightly faster than gcc, but must use the
+# clang-13 produces code that is slightly faster than gcc, but must use the
 # -fno-inline flag when compiling s25
 #
 # Use gcc for consistent optimization behavior

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Just run make and execute `./a25 -v`, `./s25 -v`, `./v25 -v` or `./525 -v`
 
 NB: Omit the **-v** option if planning to use the `time` shell call
 
-I've set the default compiler to `clang-12` in the Makefile, as this produces
+I've set the default compiler to `clang-13` in the Makefile, as this produces
 the fastest executables in my testing, but edit the Makefile and switch to
 `gcc` if that's what you have
 


### PR DESCRIPTION
You recently changed used clang version to 13, but this is not reflected in the README file. 

On a side note, is `clang-14` faster than `clang-13`?